### PR TITLE
unrelated app code in Ripple docs

### DIFF
--- a/src/app/showcase/components/ripple/rippledemo.html
+++ b/src/app/showcase/components/ripple/rippledemo.html
@@ -52,13 +52,13 @@ export class AppComponent implements OnInit &#123;
 &lt;div pRipple&gt;&lt;/div&gt;
 </app-code>
 
-<app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
+<!--<app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
 export class ModelComponent &#123;
 
     val: number;
 
 &#125;
-</app-code>
+</app-code>-->
 
             <h5>Styling</h5>
             <p>Default styling of the animation adds a shade of white. This can easily be customized using css that changes the color of <i>.p-ink</i> element.</p>


### PR DESCRIPTION
There is an unrelated app code in the directive section of the Ripple docs page. 